### PR TITLE
Adding proper base name to current-user endpoint

### DIFF
--- a/ozone/core/api/urls.py
+++ b/ozone/core/api/urls.py
@@ -25,7 +25,7 @@ class DefaultRouter(routers.DefaultRouter):
 
 router = DefaultRouter()
 
-router.register(r"current-user", views.CurrentUserViewSet)
+router.register(r"current-user", views.CurrentUserViewSet, "current_user")
 
 router.register(r"regions", views.RegionViewSet)
 router.register(r"subregions", views.SubregionViewSet)


### PR DESCRIPTION
Without a specified basename, DRF will display the same URL in the browsable API as the other view using the same model.