### PR TITLE
Disabling post forms in DRF browsable API

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -270,6 +270,10 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAdminUser',
     ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        'core.utils.api.BrowsableAPIRendererWithoutForms',
+    ),
 }
 
 

--- a/ozone/core/utils/api.py
+++ b/ozone/core/utils/api.py
@@ -1,0 +1,20 @@
+from rest_framework.renderers import BrowsableAPIRenderer
+
+
+class BrowsableAPIRendererWithoutForms(BrowsableAPIRenderer):
+    """Renders the browsable api, but excludes the forms."""
+
+    def get_context(self, *args, **kwargs):
+        ctx = super().get_context(*args, **kwargs)
+        ctx['display_edit_forms'] = False
+        return ctx
+
+    def show_form_for_method(self, view, method, request, obj):
+        """We never want to do this! So just return False."""
+        return False
+
+    def get_rendered_html_form(self, data, view, method, request):
+        """Why render _any_ forms at all. This method should return
+        rendered HTML, so let's simply return an empty string.
+        """
+        return ""

--- a/ozone/core/utils/api.py
+++ b/ozone/core/utils/api.py
@@ -2,7 +2,9 @@ from rest_framework.renderers import BrowsableAPIRenderer
 
 
 class BrowsableAPIRendererWithoutForms(BrowsableAPIRenderer):
-    """Renders the browsable api, but excludes the forms."""
+    """
+    Renders the browsable api, but excludes the forms.
+    """
 
     def get_context(self, *args, **kwargs):
         ctx = super().get_context(*args, **kwargs)
@@ -10,11 +12,14 @@ class BrowsableAPIRendererWithoutForms(BrowsableAPIRenderer):
         return ctx
 
     def show_form_for_method(self, view, method, request, obj):
-        """We never want to do this! So just return False."""
+        """
+        We never want to do this! So just return False.
+        """
         return False
 
     def get_rendered_html_form(self, data, view, method, request):
-        """Why render _any_ forms at all. This method should return
-        rendered HTML, so let's simply return an empty string.
+        """
+        This method should return rendered HTML, so let's simply return an
+        empty string.
         """
         return ""


### PR DESCRIPTION
Default checks performed by DRF (to see whether POST forms should be displayed) led to crashes in our custom permissions.

A read-only browsable API is better than no browsable API. :)