### PR TITLE
Add email hooks to all workflows

### DIFF
--- a/ozone/core/models/workflows/accelerated.py
+++ b/ozone/core/models/workflows/accelerated.py
@@ -1,6 +1,7 @@
 import xworkflows
 
 from .base import BaseWorkflow
+from .emails import notify_workflow_transitioned
 
 
 __all__ = [

--- a/ozone/core/models/workflows/accelerated.py
+++ b/ozone/core/models/workflows/accelerated.py
@@ -71,3 +71,7 @@ class AcceleratedArticle7Workflow(BaseWorkflow):
     @xworkflows.transition('unrecall')
     def unrecall(self):
         self.model_instance.make_current()
+
+    @xworkflows.on_enter_state(*[s.name for s in state.states])
+    def notify_by_email(self, *args, **kwargs):
+        notify_workflow_transitioned(self)

--- a/ozone/core/models/workflows/accelerated_exemption.py
+++ b/ozone/core/models/workflows/accelerated_exemption.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 import xworkflows
 
 from .base import BaseWorkflow
+from .emails import notify_workflow_transitioned
 from ...exceptions import TransitionFailed
 
 

--- a/ozone/core/models/workflows/accelerated_exemption.py
+++ b/ozone/core/models/workflows/accelerated_exemption.py
@@ -73,3 +73,7 @@ class AcceleratedExemptionWorkflow(BaseWorkflow):
     def finalize(self):
         self.model_instance.flag_approved = True
         self.model_instance.save()
+
+    @xworkflows.on_enter_state(*[s.name for s in state.states])
+    def notify_by_email(self, *args, **kwargs):
+        notify_workflow_transitioned(self)

--- a/ozone/core/models/workflows/default.py
+++ b/ozone/core/models/workflows/default.py
@@ -163,7 +163,3 @@ class DefaultArticle7Workflow(BaseWorkflow):
     @xworkflows.on_enter_state(*[s.name for s in state.states])
     def notify_by_email(self, *args, **kwargs):
         notify_workflow_transitioned(self)
-
-    @xworkflows.on_enter_state(*[s.name for s in state.states])
-    def notify_by_email(self, *args, **kwargs):
-        notify_workflow_transitioned(self)

--- a/ozone/core/models/workflows/default.py
+++ b/ozone/core/models/workflows/default.py
@@ -163,3 +163,7 @@ class DefaultArticle7Workflow(BaseWorkflow):
     @xworkflows.on_enter_state(*[s.name for s in state.states])
     def notify_by_email(self, *args, **kwargs):
         notify_workflow_transitioned(self)
+
+    @xworkflows.on_enter_state(*[s.name for s in state.states])
+    def notify_by_email(self, *args, **kwargs):
+        notify_workflow_transitioned(self)

--- a/ozone/core/models/workflows/default_exemption.py
+++ b/ozone/core/models/workflows/default_exemption.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 import xworkflows
 
 from .base import BaseWorkflow
+from .emails import notify_workflow_transitioned
 from ...exceptions import TransitionFailed
 
 

--- a/ozone/core/models/workflows/default_exemption.py
+++ b/ozone/core/models/workflows/default_exemption.py
@@ -94,3 +94,7 @@ class DefaultExemptionWorkflow(BaseWorkflow):
     def submit(self):
         if self.model_instance.is_submitted_at_automatically_filled(self.user):
             self.model_instance.set_submitted()
+
+    @xworkflows.on_enter_state(*[s.name for s in state.states])
+    def notify_by_email(self, *args, **kwargs):
+        notify_workflow_transitioned(self)

--- a/ozone/core/models/workflows/default_process_agent.py
+++ b/ozone/core/models/workflows/default_process_agent.py
@@ -1,6 +1,7 @@
 import xworkflows
 
 from .base import BaseWorkflow
+from .emails import notify_workflow_transitioned
 
 
 __all__ = [

--- a/ozone/core/models/workflows/default_process_agent.py
+++ b/ozone/core/models/workflows/default_process_agent.py
@@ -65,3 +65,7 @@ class DefaultProcessAgentWorkflow(BaseWorkflow):
         Ensure that only secretariat-edit users can finalize submissions
         """
         return not self.user.is_read_only and self.user.is_secretariat
+
+    @xworkflows.on_enter_state(*[s.name for s in state.states])
+    def notify_by_email(self, *args, **kwargs):
+        notify_workflow_transitioned(self)

--- a/ozone/core/models/workflows/default_transfer.py
+++ b/ozone/core/models/workflows/default_transfer.py
@@ -1,6 +1,7 @@
 import xworkflows
 
 from .base import BaseWorkflow
+from .emails import notify_workflow_transitioned
 
 
 __all__ = [

--- a/ozone/core/models/workflows/default_transfer.py
+++ b/ozone/core/models/workflows/default_transfer.py
@@ -65,3 +65,7 @@ class DefaultTransferWorkflow(BaseWorkflow):
         Ensure that only secretariat-edit users can finalize submissions
         """
         return not self.user.is_read_only and self.user.is_secretariat
+
+    @xworkflows.on_enter_state(*[s.name for s in state.states])
+    def notify_by_email(self, *args, **kwargs):
+        notify_workflow_transitioned(self)


### PR DESCRIPTION
Addresses https://github.com/eaudeweb/ozone/issues/1091

https://github.com/eaudeweb/ozone/pull/1123 added hooks to `DefaultArticle7Workflow`, but there are others. This patch adds the hooks to the other workflows. This has not been tested yet, how do we go about verifying that the emails are being sent correctly?