### PR TITLE
Reuse test database

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=config.settings.test
-addopts=--ignore frontend
+DJANGO_SETTINGS_MODULE = config.settings.test
+addopts = --ignore frontend --reuse-db


### PR DESCRIPTION
Reduce the time to run a single test with pytest from 45 seconds to 5 seconds by reusing the test database fixtures ([`--reuse-db`](https://pytest-django.readthedocs.io/en/latest/database.html#reuse-db-reuse-the-testing-database-between-test-runs)).

Run pytest with `--create-db` to overrdie this behaviour.
