### PR TITLE
Changing media root to something non-tusd

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -211,7 +211,7 @@ STATICFILES_DIRS = (
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-root
 MEDIA_URL = '/media/'
-MEDIA_ROOT = '/var/local/tusd_uploads'
+MEDIA_ROOT = '/var/local/media'
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,8 @@ volumes:
     driver: local
   tusd-uploads:
     driver: local
+  media:
+    driver: local
   weblate-data:
     driver: local
   pg-weblate-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - ./docker/app.env
     volumes:
      - tusd-uploads:/var/local/tusd_uploads
+     - media:/var/local/media
     depends_on:
       - postgres
       - tusd


### PR DESCRIPTION
This will allow public uploads (with public URLs) to be separated from tusd uploads (which are uploaded through tusd, served through API views and permission-controlled).

Relates to #1184 