### PR TITLE
Quantize blend values to `DECIMAL_FIELD_DIGITS`

### DIFF
--- a/ozone/core/models/data.py
+++ b/ozone/core/models/data.py
@@ -16,7 +16,8 @@ from .utils import (
     model_to_dict,
     decimal_zero_if_none,
     DECIMAL_FIELD_DIGITS,
-    DECIMAL_FIELD_DECIMALS
+    DECIMAL_FIELD_DECIMALS,
+    quantize,
 )
 
 
@@ -156,6 +157,8 @@ class BlendCompositionMixin:
                 attributes['substance_id'] = component.substance.pk
                 attributes['blend_item_id'] = self.pk
                 attributes.update(field_dictionary)
+                attributes['quantity_feedstock'] = quantize(attributes['quantity_feedstock'])
+                attributes['quantity_total_new'] = quantize(attributes['quantity_total_new'])
                 self.__class__.objects.create(**attributes)
 
 

--- a/ozone/core/models/data.py
+++ b/ozone/core/models/data.py
@@ -144,7 +144,7 @@ class BlendCompositionMixin:
                 for field in self.QUANTITY_FIELDS:
                     # Compute individual substance quantities
                     quantity = getattr(self, field)
-                    field_dictionary[field] = component.percentage * quantity \
+                    field_dictionary[field] = quantize(component.percentage * quantity) \
                         if quantity else None
 
                 attributes = model_to_dict(
@@ -157,8 +157,6 @@ class BlendCompositionMixin:
                 attributes['substance_id'] = component.substance.pk
                 attributes['blend_item_id'] = self.pk
                 attributes.update(field_dictionary)
-                attributes['quantity_feedstock'] = quantize(attributes['quantity_feedstock'])
-                attributes['quantity_total_new'] = quantize(attributes['quantity_total_new'])
                 self.__class__.objects.create(**attributes)
 
 

--- a/ozone/core/models/utils.py
+++ b/ozone/core/models/utils.py
@@ -60,3 +60,9 @@ def float_to_decimal_zero_if_none(value):
 def float_to_decimal(value):
     """Converts null-able float to decimal, returns None if value is None"""
     return decimal.Decimal(str(value)) if value else None
+
+
+def quantize(value):
+    """Quantize to DECIMAL_FIELD_DECIMALS decimal places"""
+    quant = Decimal(10) ** -DECIMAL_FIELD_DECIMALS
+    return value.quantize(quant)


### PR DESCRIPTION
Blend values are calculated and they end up with too many decimal places, and the database refuses to save them. This patch applies quantize again on them.
