### PR TITLE
Test import blends

### DIFF
--- a/ozone/tests/fixtures_for_importing.py
+++ b/ozone/tests/fixtures_for_importing.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+from ozone.core import models
+from . import factories
+
+
+def get_required_fixtures(data, blend_list):
+    party_set = set()
+    period_set = set()
+    substance_set = set()
+
+    for row in data.tables['Overall'].rows:
+        party_set.add(row['CntryID'])
+        period_set.add(row['PeriodID'])
+
+    for row in data.tables['ImportNew'].rows:
+        party_set.add(row['OrgCntryID'])
+
+    for row in data.tables['Export'].rows:
+        party_set.add(row['DestCntryID'])
+
+    for row in data.tables['NonPartyTradeNew'].rows:
+        party_set.add(row['SrcDestCntryID'])
+
+    for sheet in ['Import', 'ImportNew', 'Export', 'Produce', 'Destroy',
+                  'NonPartyTrade', 'NonPartyTradeNew']:
+        for row in data.tables[sheet].rows:
+            substance_set.add(row['SubstID'])
+
+    blend_set = set(b[0] for b in blend_list)
+    substance_set -= blend_set
+    party_set -= set(['UNK'])
+
+    return {
+        'party_list': sorted(party_set),
+        'period_list': sorted(period_set),
+        'substance_list': sorted(substance_set - blend_set),
+        'blend_list': blend_list,
+    }
+
+
+def create_fixtures(subregion, party_list, period_list,
+                    substance_list, blend_list=[]):
+    for abbr in party_list:
+        factories.PartyFactory(
+            abbr=abbr,
+            name=f"{abbr} party",
+            subregion=subregion,
+        )
+
+    for name in period_list:
+        factories.ReportingPeriodFactory(
+            name=name,
+            start_date=datetime.strptime('2009-01-01', '%Y-%m-%d'),
+            end_date=datetime.strptime('2009-12-31', '%Y-%m-%d'),
+        )
+
+    for substance_id in substance_list:
+        factories.SubstanceFactory(
+            substance_id=substance_id,
+            name=f"Chemical {substance_id}",
+        )
+
+    for legacy_blend_id, components in blend_list:
+        blend = factories.BlendFactory(
+            blend_id=str(legacy_blend_id),
+            legacy_blend_id=legacy_blend_id,
+        )
+        for substance_id, percentage in components:
+            blend.components.create(
+                substance=models.Substance.objects.get(
+                    substance_id=substance_id),
+                percentage=percentage,
+            )

--- a/ozone/tests/test_export.py
+++ b/ozone/tests/test_export.py
@@ -1,14 +1,14 @@
 from decimal import Decimal as D
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from datetime import datetime
 from django.contrib.auth.hashers import Argon2PasswordHasher
 from ozone.core.management.commands import import_submissions
 from ozone.core.management.commands import export_submissions
 from ozone.core.utils.spreadsheet import OzoneSpreadsheet
-from ozone.core import models
 from .base import BaseTests
 from . import factories
+from .fixtures_for_importing import get_required_fixtures
+from .fixtures_for_importing import create_fixtures
 
 examples = Path(__file__).resolve().parent / 'examples'
 
@@ -119,39 +119,6 @@ def assert_spreadsheets_are_same(s1, s2):
 
 class ExportTest(BaseTests):
 
-    def create_fixtures(self, party_list, period_list, substance_list, blend_list=[]):
-        for abbr in party_list:
-            factories.PartyFactory(
-                abbr=abbr,
-                name=f"{abbr} party",
-                subregion=self.subregion,
-            )
-
-        for name in period_list:
-            factories.ReportingPeriodFactory(
-                name=name,
-                start_date=datetime.strptime('2009-01-01', '%Y-%m-%d'),
-                end_date=datetime.strptime('2009-12-31', '%Y-%m-%d'),
-            )
-
-        for substance_id in substance_list:
-            factories.SubstanceFactory(
-                substance_id=substance_id,
-                name=f"Chemical {substance_id}",
-            )
-
-        for legacy_blend_id, components in blend_list:
-            blend = factories.BlendFactory(
-                blend_id=str(legacy_blend_id),
-                legacy_blend_id=legacy_blend_id,
-            )
-            for substance_id, percentage in components:
-                blend.components.create(
-                    substance=models.Substance.objects.get(
-                        substance_id=substance_id),
-                    percentage=percentage,
-                )
-
     def setUp(self):
         super().setUp()
         self.language = factories.LanguageEnFactory()
@@ -164,40 +131,6 @@ class ExportTest(BaseTests):
         factories.ReportingChannelFactory(name="Legacy")
         factories.ObligationFactory(pk=1)
 
-    def get_required_fixtures(self, data, blend_list):
-        party_set = set()
-        period_set = set()
-        substance_set = set()
-
-        for row in data.tables['Overall'].rows:
-            party_set.add(row['CntryID'])
-            period_set.add(row['PeriodID'])
-
-        for row in data.tables['ImportNew'].rows:
-            party_set.add(row['OrgCntryID'])
-
-        for row in data.tables['Export'].rows:
-            party_set.add(row['DestCntryID'])
-
-        for row in data.tables['NonPartyTradeNew'].rows:
-            party_set.add(row['SrcDestCntryID'])
-
-        for sheet in ['Import', 'ImportNew', 'Export', 'Produce', 'Destroy',
-                      'NonPartyTrade', 'NonPartyTradeNew']:
-            for row in data.tables[sheet].rows:
-                substance_set.add(row['SubstID'])
-
-        blend_set = set(b[0] for b in blend_list)
-        substance_set -= blend_set
-        party_set -= set(['UNK'])
-
-        return {
-            'party_list': sorted(party_set),
-            'period_list': sorted(period_set),
-            'substance_list': sorted(substance_set - blend_set),
-            'blend_list': blend_list,
-        }
-
     def test_export_submissions_imports(self):
         in_path = examples / 'art7_submissions.xlsx'
         in_data = OzoneSpreadsheet.from_xlsx(in_path)
@@ -207,8 +140,8 @@ class ExportTest(BaseTests):
                 (102, D('0.7')),
             ]),
         ]
-        fixtures = self.get_required_fixtures(in_data, blend_list=blend_list)
-        self.create_fixtures(**fixtures)
+        fixtures = get_required_fixtures(in_data, blend_list=blend_list)
+        create_fixtures(self.subregion, **fixtures)
         invoke_import_submissions(file=in_path)
 
         with TemporaryDirectory() as tmp:

--- a/ozone/tests/test_import.py
+++ b/ozone/tests/test_import.py
@@ -1,0 +1,68 @@
+from decimal import Decimal as D
+from pathlib import Path
+from django.contrib.auth.hashers import Argon2PasswordHasher
+from ozone.core.management.commands import import_submissions
+from ozone.core.utils.spreadsheet import OzoneSpreadsheet
+from ozone.core import models
+from .base import BaseTests
+from . import factories
+from .fixtures_for_importing import get_required_fixtures
+from .fixtures_for_importing import create_fixtures
+
+examples = Path(__file__).resolve().parent / 'examples'
+
+
+def invoke_import_submissions(**kwargs):
+    kwargs = dict({
+        'recreate': False,
+        'purge': False,
+        'limit': None,
+        'precision': 10,
+        'use_cache': False,
+        'dry_run': False,
+        'single': False,
+        'verbosity': 1,
+    }, **kwargs)
+    cmd = import_submissions.Command()
+    cmd.handle(**kwargs)
+
+
+class ImportTest(BaseTests):
+
+    def setUp(self):
+        super().setUp()
+        self.language = factories.LanguageEnFactory()
+        hash_alg = Argon2PasswordHasher()
+        self.secretariat_user = factories.SecretariatUserFactory(
+            language=self.language,
+            password=hash_alg.encode(password="qwe123qwe", salt="123salt123"),
+        )
+        self.subregion = factories.SubregionFactory()
+        factories.ReportingChannelFactory(name="Legacy")
+        factories.ObligationFactory(pk=1)
+
+    def test_blend_is_expanded_into_components(self):
+        in_path = examples / 'art7_submissions.xlsx'
+        in_data = OzoneSpreadsheet.from_xlsx(in_path)
+        blend_list = [
+            (369, [
+                (101, D('0.3')),
+                (102, D('0.7')),
+            ]),
+        ]
+        fixtures = get_required_fixtures(in_data, blend_list=blend_list)
+        create_fixtures(self.subregion, **fixtures)
+        invoke_import_submissions(file=in_path)
+
+        s101 = models.Substance.objects.get(substance_id='101')
+        s102 = models.Substance.objects.get(substance_id='102')
+        [submission] = models.Submission.objects.all()
+
+        import_blends = {
+            row.substance: row for row in
+            submission.article7imports.filter(blend_item_id__isnull=False)
+        }
+
+        assert set(import_blends.keys()) == set([s101, s102])
+        assert import_blends[s101].quantity_total_new == D('18')
+        assert import_blends[s102].quantity_total_new == D('42')


### PR DESCRIPTION
Make sure blends are expanded into component substances upon import from xlsx.

@melish I've made an assertion for the `ImportNew` sheet, `ImpNew` column (`quantity_total_new`). How deep should I go into the combinatorial explosion of sheets and columns with the assertions? The documentation for `BlendCompositionMixin` [says](https://github.com/eaudeweb/ozone/blob/1fee0fb816859b82dd4589dfe1e06abe8aa35f1c/ozone/core/models/data.py#L46-L47) that, as long as `QUANTITY_FIELDS` is defined correctly for each model, the proper fields would be expanded. It makes sense to assert for one, and trust that the models are defined correctly.
