### PR TITLE
Workflow notification emails

### DIFF
--- a/ozone/core/email.py
+++ b/ozone/core/email.py
@@ -6,18 +6,26 @@ def send_mail_from_template(
     subject_template_name,
     email_template_name,
     context,
-    to_email,
+    to_emails,
+    cc_emails=None,
     from_email=None,
     html_email_template_name=None,
 ):
     """
-    Send a django.core.mail.EmailMultiAlternatives to `to_email`.
+    Send a django.core.mail.EmailMultiAlternatives to `to_emails`.
     """
     subject = loader.render_to_string(subject_template_name, context)
     subject = "".join(subject.splitlines())
     body = loader.render_to_string(email_template_name, context)
 
-    email_message = EmailMultiAlternatives(subject, body, from_email, [to_email])
+    email_message = EmailMultiAlternatives(
+        subject=subject,
+        body=body,
+        from_email=from_email,
+        to=to_emails,
+        cc=cc_emails,
+    )
+
     if html_email_template_name is not None:
         html_email = loader.render_to_string(html_email_template_name, context)
         email_message.attach_alternative(html_email, "text/html")

--- a/ozone/core/models/workflows/emails.py
+++ b/ozone/core/models/workflows/emails.py
@@ -5,8 +5,8 @@ from ozone.core.utils.site import get_site_name
 
 
 def allow_sending_to(email):
-    # if re.search(r'@example\.(com|org)$', email):
-    #     return False
+    if re.search(r'@example\.(com|org)$', email):
+        return False
 
     return True
 

--- a/ozone/core/models/workflows/emails.py
+++ b/ozone/core/models/workflows/emails.py
@@ -1,6 +1,7 @@
 import re
 from ozone.core.models import User
 from ozone.core.email import send_mail_from_template
+from ozone.core.utils.site import get_site_name
 
 
 def skip(email):
@@ -11,9 +12,14 @@ def skip(email):
 def notify_workflow_transitioned(workflow):
     submission = workflow.model_instance
     context = {
-        'submission': submission,
-        'user': workflow.user,
-        'new_state': workflow.state,
+        'user': str(workflow.user),
+        'new_state': str(workflow.state).upper(),
+        'submission': str(submission),
+        'party': submission.party.name,
+        'obligation': submission.obligation.name,
+        'reporting_period': submission.reporting_period.name,
+        'version': str(submission.version),
+        'site_name': get_site_name(),
     }
 
     recipients = [u.email for u in User.objects.filter(is_secretariat=True)]

--- a/ozone/core/utils/site.py
+++ b/ozone/core/utils/site.py
@@ -1,0 +1,7 @@
+from django.contrib.sites.models import Site
+
+
+def get_site_name():
+    """ Return the name of the first site we find, or the empty string """
+    site = Site.objects.all().first()
+    return site.name if site else ""

--- a/ozone/core/views.py
+++ b/ozone/core/views.py
@@ -45,6 +45,6 @@ class ActivateUserPasswordResetConfirmView(PasswordResetConfirmView):
                         "account": self.user,
                         "site_name": self.request.META.get("HTTP_HOST")
                     },
-                    to_email=self.user.created_by.email
+                    to_emails=[self.user.created_by.email],
                 )
         return result

--- a/ozone/templates/registration/workflow_transitioned_email.html
+++ b/ozone/templates/registration/workflow_transitioned_email.html
@@ -1,5 +1,7 @@
 {% load i18n %}{% autoescape off %}
-{% blocktrans %}Submission {{ submission }} has been changed to {{ new_state }} by {{ user }}.{% endblocktrans %}
+{% blocktrans %}{{ party }} has {{ new_state }} its report on {{ obligation }} for {{ reporting_period }} - this being submission number {{ version }}.
+
+Submitted by {{ user }}.{% endblocktrans %}
 
 {% blocktrans %}The {{ site_name }} team{% endblocktrans %}
 


### PR DESCRIPTION
Fixes https://github.com/eaudeweb/ozone/issues/1236

* Send a single message with "to" secretariat, "cc" party users and the email in the submission. (Sending to all party users is new, this is what we want, no?)
* Helper function to dig out the `site_name`, hopefully we'll only ever have one site per database.
