### PR TITLE
Return 404 for non-public media files

### DIFF
--- a/config/nginx/nginx.conf.example
+++ b/config/nginx/nginx.conf.example
@@ -43,8 +43,11 @@ server {
       root /var/local/certbot;
   }
 
-  location /media/public/ {
-      alias /opt/ozone/media/public/;
+  location /media/ {
+      location /media/public/ {
+          alias /opt/ozone/media/public/;
+      }
+      return 404;
   }
 
   location /mailtrap {


### PR DESCRIPTION
Follow up to https://github.com/eaudeweb/ozone/pull/1303 - return a 404 page instead of the homepage for non-public media files